### PR TITLE
Really use the pdf generated binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ ex_pdf-*.tar
 
 # Temporary files for e.g. tests
 /tmp
+
+/venv/

--- a/lib/ex_pdf/python_worker.ex
+++ b/lib/ex_pdf/python_worker.ex
@@ -23,8 +23,8 @@ defmodule ExPdf.PythonWorker do
   end
 
   def handle_call(%{html: html}, _from, %{python_pid: pid} = state) do
-    PythonPort.call_python(pid, :pdf, :generate, [html])
+    pdf = PythonPort.call_python(pid, :pdf, :generate, [html])
 
-    {:reply, :ok, state}
+    {:reply, pdf, state}
   end
 end


### PR DESCRIPTION
If we intend to use the generated pdf binary directly, we need to transfer it.